### PR TITLE
Switch to s6-overlay variant of open-balena-base

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,24 @@
-FROM balena/open-balena-base:19.1.3
+FROM balena/open-balena-base:19.1.3-s6-overlay
 
-ENV NGINX_VERSION 1.24.0-1~bookworm
+# Install gnupg to allow us to add the nginx signing key
+# hadolint ignore=DL3008
+RUN apt-get update \
+	&& apt-get install -y --no-install-recommends \
+		gnupg \
+	&& rm -rf /var/lib/apt/lists/*
+
+ENV NGINX_VERSION=1.24.0-1~bookworm
+
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 # Note that we stop nginx from being available in systemd, as we run it manually in downstream images
+# hadolint ignore=DL3008
 RUN wget -q -O - https://nginx.org/keys/nginx_signing.key | apt-key add - \
 	&& echo 'deb http://nginx.org/packages/debian/ bookworm nginx' >> /etc/apt/sources.list \
 	&& apt-get update -y \
-	&& apt-get install rpl chromium nginx=${NGINX_VERSION} \
+	&& apt-get install -y --no-install-recommends rpl chromium nginx=${NGINX_VERSION} \
 	&& rm /etc/init.d/nginx \
 	&& rm -rf /etc/nginx/conf.d/* \
 	&& rm -rf /etc/nginx/sites-available/* \
 	&& rm -rf /etc/nginx/sites-enabled/* \
-	&& rm -rf /var/lib/apt/lists/* \
-	&& systemctl mask nginx.service
+	&& rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
This allows running with reduced permissions and
avoids conflicts with hosts running cgroups v2.

This is a breaking change for any consuming components
that were enabling services via systemd unit files.

Change-type: major
See: https://balena.fibery.io/Work/Improvement/Remove-systemd-from-balena-admin-3035